### PR TITLE
Pacote babel, entrada no package.json, instalação yeoman e generators vtex

### DIFF
--- a/pt-BR/avancado/melhorando-o-desenvolvimento.md
+++ b/pt-BR/avancado/melhorando-o-desenvolvimento.md
@@ -20,6 +20,13 @@ Para resolver tudo isso, usamos a ferramenta de build [Webpack](https://webpack.
 
 Neste guia vamos apagar toda a estrutura criada no Tutorial básico e começá-la do zero com essa nova estrutura de desenvolvimento.
 
+Para os passos a seguir, você deverá instalar os pacotes `yo` e `generator-vtex` (lembrando de usar `sudo` ou equivalente caso seja necessário):
+
+```sh
+$ npm install -g yo
+$ npm install -g generator-vtex
+```
+
 Apague todos os arquivos da pasta de seu app. Abra o terminal na mesma pasta e digite:
 
 ```sh

--- a/pt-BR/primeiros-passos/componente-react.md
+++ b/pt-BR/primeiros-passos/componente-react.md
@@ -33,7 +33,9 @@ class HomePage extends React.Component {
 
 Como ele é um arquivo que contém código JSX, devemos compila-lo.
 
-Instale o babel com: `npm install babel-cli`. Para usa-lo digite:
+Instale o babel com: `npm install babel-cli`. É necessário também instalar um pacote extra para habilitar a integração com o React: `npm install babel-preset-react`.
+
+Para compilar o arquivo digite:
 
 ```sh
 babel ./storefront/assets/**.jsx --out-dir .

--- a/pt-BR/primeiros-passos/manifest.md
+++ b/pt-BR/primeiros-passos/manifest.md
@@ -69,7 +69,7 @@ Crie o seu meta.json com:
 
 Ao desenvolver um app no Storefront você **deve** colocar "vtex.storefront" e "vtex.storefront-sdk" como dependências.
 
-**Aviso:** Durante os exemplos da documentação, lembre-se sempre de substituir o "my-frist-app" e o "mycompany" com o nome que escolheu para o _name_ e _vendor_.
+**Aviso:** Durante os exemplos da documentação, lembre-se sempre de substituir o "my-first-app" e o "mycompany" com o nome que escolheu para o _name_ e _vendor_.
 
 ---
 

--- a/pt-BR/primeiros-passos/package.md
+++ b/pt-BR/primeiros-passos/package.md
@@ -1,9 +1,9 @@
 ### Package.json
 
-Usamos o [npm](https://www.npmjs.com/) como gerenciador de pacotes. Desta forma, voce pode com facilidade adicionar dependencias
+Usamos o [npm](https://www.npmjs.com/) como gerenciador de pacotes. Desta forma, voce pode com facilidade adicionar dependências
 aos diferentes pacotes disponibilizados.
 
-Crie  na pasta raíz o arquivo `package.json`.
+Crie  na pasta raiz o arquivo `package.json`.
 
 Você deve ter algo assim:
 

--- a/pt-BR/primeiros-passos/package.md
+++ b/pt-BR/primeiros-passos/package.md
@@ -23,6 +23,9 @@ Exemplo do package.json do app [vtex.storefront-theme](https://github.com/vtex-a
   "private": true,
   "devDependencies": {
     "react": "^0.14.0"
+  },
+  "babel":{
+    "presets": ["react"]
   }
 }
 

--- a/pt-BR/primeiros-passos/root.md
+++ b/pt-BR/primeiros-passos/root.md
@@ -1,6 +1,6 @@
 # Componente Root
 
-Para que o Storefront saiba qual componente irá atender a uma determinada rota precisamos estabeler uma associação entre os dois: _rota_ e _componente_.
+Para que o Storefront saiba qual componente irá atender a uma determinada rota precisamos estabelecer uma associação entre os dois: _rota_ e _componente_.
 
 Esta associação é feita quando configuramos o componente nativo da plataforma: o `Root@vtex.storefront-sdk`.
 

--- a/pt-BR/primeiros-passos/rota.md
+++ b/pt-BR/primeiros-passos/rota.md
@@ -50,4 +50,4 @@ No exemplo foi criado o arquivo `home.json` com a propriedade `path` sendo `/`. 
 
 ### Próximos passos
 
-Criamos a rota `home`. Vamos agora associar um componente React uma a rota [configurando o componente Root](root.md).
+Criamos a rota `home`. Vamos agora associar um componente React a uma rota [configurando o componente Root](root.md).

--- a/pt-BR/primeiros-passos/toolbelt.md
+++ b/pt-BR/primeiros-passos/toolbelt.md
@@ -37,7 +37,7 @@ login: email@dominio.com  // seu email registrado na loja de teste. Email padrã
 password - ******
 ```
 
-Após fazer login, rode o comando `vtex watch` para enviar os arquivos para o ambiente de desenvolvimento.
+Após fazer login, rode o comando `vtex watch` (de dentro da pasta onde seu app está) para enviar os arquivos para o ambiente de desenvolvimento.
 
 Por fim, abra a URL que o Toolbelt mostra em seu terminal.
 


### PR DESCRIPTION
Olá pessoal.

Eu estava seguindo o tutorial e deu um pequeno erro de compilação quando eu rodei o comando `babel`:

```
(jekyll-venv)vagrant@playvm:~/metrics-app$ node_modules/.bin/babel ./storefront/assets/**.jsx --out-dir .
SyntaxError: ./storefront/assets/HomePage.jsx: Unexpected token (6:6)
  4 |   render() {
  5 |     return (
> 6 |       <h1>Hello world!</h1>
    |       ^
  7 |     );
  8 |   }
  9 | }
```

 Eu dei uma olhada pelo stackoverflow [link](http://stackoverflow.com/questions/33460420/babel-loader-jsx-syntaxerror-unexpected-token) e parece que precisa instalar mais um pacote npm e adicionar uma entrada no `package.json`. 

Eu acho que é a isso que o ticket #30 se refere. Eu não manjo nada de nodejs então é possível que esteja errado mas acho que tá certo.