### PR TITLE
Adiciona informação sobre campo 'dependencies'

### DIFF
--- a/pt-BR/avancado/ambiente-de-desenvolvimento.md
+++ b/pt-BR/avancado/ambiente-de-desenvolvimento.md
@@ -1,8 +1,8 @@
 # Ambiente de desenvolvimento
 
-A plataforma fornece um ambiente seguro para o desenvolvimento de aplicações. Desta forma, os desenvolvedores recebem feedback imediato do estado final da app durante a sua construção, podendo testar e corrigir bugs antes de publicarem uma nova versão.
+A plataforma fornece um ambiente seguro para o desenvolvimento de aplicações, permitindo que desenvolvedores possam trabalhar localmente testando e corrigindo bugs antes de publicarem uma nova versão.
 
-O desenvolvedor pode customizar e testar alterações simulando o comportamento de um lojista sem afetar a loja em produção. Além disso, não existe limite para a quantidade de apps que podem ser desenvolvidas paralelamente, permitindo em um mesmo ambiente mesclar apps em desenvolvimento com apps que já estão instaladas na loja.
+O desenvolvedor pode customizar e testar alterações simulando o comportamento de um lojista sem afetar a loja em produção, não existe limite para a quantidade de apps que podem ser desenvolvidas paralelamente. Em um mesmo ambiente é possível mesclar apps em desenvolvimento com apps que já estejam instaladas na loja.
 
-Nos próximos passos veremos como melhorar a experiencia de desenvolvimento e entenderemos conceitualmente como o ambiente de desenvolvimento funciona.
-
+## Próximos passos
+Nos próximos passos veremos como melhorar a experiência de desenvolvimento e entenderemos conceitualmente como o fluxo de desenvolvimento funciona.

--- a/pt-BR/primeiros-passos/manifest.md
+++ b/pt-BR/primeiros-passos/manifest.md
@@ -27,7 +27,7 @@ Exemplo do manifest do app [vtex.storefront-theme](https://github.com/vtex-apps/
 
 ### vendor
 
-O vendor é o nome da conta que você pertence como desenvolvedor. Por exemplo, se você trabalha na VTEX, será "vtex", se você trabalha na Profite, provavelmente será "profite". Lembramos que os nomes dos vendors podem ser _genéricos_, os exemplos são apenas uma ilustração.
+O vendor é o nome da conta que você pertence como desenvolvedor. Por exemplo, se você trabalha na VTEX, será "vtex", se você trabalha na Profite, provavelmente será "profite".
 
 ### name
 
@@ -47,7 +47,7 @@ Descrição.
 
 ### dependencies
 
-Aqui são listados os apps que seu app tem como dependência.
+Aqui são listados os apps que seu app tem como dependência. É importante dizer que as dependência declaradas no arquivo `manifest.json` **não fazem download do código fonte localmente**, são referências para apps que estão instaladas na loja.
 
 ---
 


### PR DESCRIPTION
Fui questionado pelos desenvolvedores sobre o uso do campo 'dependencies' do manifest.json. Na visão deles, os arquivos são baixados localmente.

Para evitar dúvidas adicionei uma descrição ao campo `dependencies` na documentação de ambiente de desenvolvimento.